### PR TITLE
feat: Update navigation methods to use replace for smoother transitio…

### DIFF
--- a/mobile/.expo/devices.json
+++ b/mobile/.expo/devices.json
@@ -2,7 +2,7 @@
   "devices": [
     {
       "installationId": "f35e734e-090c-495d-b241-ed016531c345",
-      "lastUsed": 1748208994276
+      "lastUsed": 1748233778561
     },
     {
       "installationId": "b792b9d3-04ae-4454-b1a7-beafdc986831",

--- a/mobile/src/screens/Auth/ForgotPassword/Screens/VerificationScreen/VerificationScreen.tsx
+++ b/mobile/src/screens/Auth/ForgotPassword/Screens/VerificationScreen/VerificationScreen.tsx
@@ -46,7 +46,6 @@ function VerificationScreen({ onSuccess, email, onSingUp }: VerificationScreenPr
                         </Text>
                         {countdown === 0 && <TextGradient style={styles.resendStrong} text=' Resend' />}
                     </TouchableOpacity>
-
                     {/* Submit Button */}
                     <GradientButton
                         Square
@@ -57,20 +56,18 @@ function VerificationScreen({ onSuccess, email, onSingUp }: VerificationScreenPr
                     >
                         <Text style={styles.submitText}>Send</Text>
                     </GradientButton>
-
                     {/* Sign Up */}
                     <Text style={styles.haveAccountText}>Do you have an account?</Text>
                     <TouchableOpacity style={styles.signupBtn} onPress={onSingUp}>
                         <Text style={styles.signupText}>Sign up</Text>
                     </TouchableOpacity>
-
-                    {/* Facebook Login */}
+                    {/* Facebook Login
                     <TouchableOpacity style={styles.facebookBtn} onPress={loginWithFacebook}>
                         <View style={styles.facebookContent}>
                             <FontAwesome name='facebook' size={20} color='#8F8F8F' style={{ marginRight: 8 }} />
                             <Text style={styles.facebookText}>Login with Facebook</Text>
                         </View>
-                    </TouchableOpacity>
+                    </TouchableOpacity> */}
                 </View>
             </View>
         </FormProvider>

--- a/mobile/src/screens/Auth/Login/Login.tsx
+++ b/mobile/src/screens/Auth/Login/Login.tsx
@@ -18,7 +18,7 @@ function Login({ navigation }: RootStackScreenProps<'Login'>) {
     }, [navigation])
 
     const handleGoToRegister = useCallback(() => {
-        navigation.navigate('Register')
+        navigation.replace('Register')
     }, [navigation])
 
     return (

--- a/mobile/src/screens/Auth/Register/Register.tsx
+++ b/mobile/src/screens/Auth/Register/Register.tsx
@@ -21,7 +21,7 @@ function Register({ navigation }: RootStackScreenProps<'Register'>) {
                         isValid={methods.formState.isValid}
                         isLoading={registerMutation.isPending}
                         onSubmit={handleRegister}
-                        goToLogin={() => navigation.navigate('Login')}
+                        goToLogin={() => navigation.replace('Login')}
                     />
                 </View>
             </TouchableWithoutFeedback>

--- a/mobile/src/services/rest/auth.rest.ts
+++ b/mobile/src/services/rest/auth.rest.ts
@@ -23,7 +23,6 @@ const authApi = {
 
     logout() {
         const body = { refresh_token: storage.getRefreshToken() }
-        console.log(storage.getRefreshToken())
         return http.post(process.env.EXPO_PUBLIC_URL_LOGOUT, body)
     },
 
@@ -36,6 +35,7 @@ const authApi = {
     },
 
     resentOTPForgotPassword(body: Omit<ForgotPasswordReqBody, 'otp'>) {
+        console.log('Resending OTP for forgot password:', body)
         return http.post<ResponseApi<any, any>>(process.env.EXPO_PUBLIC_URL_RESEND_OTP_FORGOT_PASSWORD, body)
     },
 


### PR DESCRIPTION
This pull request introduces several updates across the mobile application, including navigation improvements, code cleanup, and minor UI adjustments. The most significant changes involve replacing navigation methods for consistency, removing unused code, and adding logging for better debugging.

### Navigation Improvements:
* Replaced `navigation.navigate` with `navigation.replace` in the `Login` and `Register` screens to ensure users cannot navigate back to the previous screen after transitioning. (`mobile/src/screens/Auth/Login/Login.tsx` [[1]](diffhunk://#diff-bf47e59ee6427e3e947414078f476bfe67235a43f6edd158d9744b58ca1d974fL21-R21) `mobile/src/screens/Auth/Register/Register.tsx` [[2]](diffhunk://#diff-469e3cf9d0f4eedfe52ee0d665b3aa4bfac36ae6edf6cd0242fb39ce60708669L24-R24)

### Code Cleanup:
* Removed an unnecessary `console.log` statement in the `logout` method of `authApi`. (`mobile/src/services/rest/auth.rest.ts` [mobile/src/services/rest/auth.rest.tsL26](diffhunk://#diff-d9539ad569fc0893eebeded439b22a053dfd0b3910882150431ef9036fa6644cL26))
* Commented out the Facebook login button in the `VerificationScreen` component, possibly for future reimplementation or removal. (`mobile/src/screens/Auth/ForgotPassword/Screens/VerificationScreen/VerificationScreen.tsx` [mobile/src/screens/Auth/ForgotPassword/Screens/VerificationScreen/VerificationScreen.tsxL60-R70](diffhunk://#diff-86c47340b7bfec1e48a0fcdda6775da39d33b9d2dc182221c2a6ac534a4db466L60-R70))

### Debugging Enhancements:
* Added a `console.log` statement to log the body of the `resentOTPForgotPassword` method for better debugging during OTP resend operations. (`mobile/src/services/rest/auth.rest.ts` [mobile/src/services/rest/auth.rest.tsR38](diffhunk://#diff-d9539ad569fc0893eebeded439b22a053dfd0b3910882150431ef9036fa6644cR38))

### Minor Adjustments:
* Updated the `lastUsed` timestamp in the `devices.json` file, likely reflecting a recent device interaction. (`mobile/.expo/devices.json` [mobile/.expo/devices.jsonL5-R5](diffhunk://#diff-de581b402df82f409982bf2434747dd9f5f871eaddbab86fd484e282ccc0027aL5-R5))…ns and improve logging for OTP resend functionality